### PR TITLE
Update sctk to `0.19.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.65.0"
 
 [dependencies]
 libc = "0.2.149"
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", default-features = false, features = [
+sctk = { package = "smithay-client-toolkit", version = "0.19.1", default-features = false, features = [
     "calloop",
-], rev = "3bed072" }
+] }
 wayland-backend = { version = "0.3.3", default_features = false, features = [
     "client_system",
 ] }
@@ -25,10 +25,10 @@ raw-window-handle = { version = "0.6", optional = true }
 
 [dev-dependencies]
 dirs = "5.0.1"
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", default-features = false, features = [
+sctk = { package = "smithay-client-toolkit", version = "0.19.1", default-features = false, features = [
     "calloop",
     "xkbcommon",
-], rev = "3bed072" }
+] }
 thiserror = "1.0.57"
 url = "2.5.0"
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,6 +16,7 @@ use sctk::output::{OutputHandler, OutputState};
 use sctk::primary_selection::device::{PrimarySelectionDevice, PrimarySelectionDeviceHandler};
 use sctk::primary_selection::selection::{PrimarySelectionSource, PrimarySelectionSourceHandler};
 use sctk::primary_selection::PrimarySelectionManagerState;
+use sctk::reexports::client::protocol::wl_output::WlOutput;
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 use sctk::registry::{ProvidesRegistryState, RegistryState};
 use sctk::seat::pointer::{PointerData, PointerEvent, PointerEventKind, PointerHandler};
@@ -666,6 +667,24 @@ impl<T: 'static + Clone> CompositorHandler for State<T> {
         _qh: &QueueHandle<Self>,
         _surface: &sctk::reexports::client::protocol::wl_surface::WlSurface,
         _time: u32,
+    ) {
+    }
+
+    fn surface_enter(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: &WlOutput,
+    ) {
+    }
+
+    fn surface_leave(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: &WlOutput,
     ) {
     }
 }


### PR DESCRIPTION
Once this is merged it can be tagged, and used in `window_clipboard`.

Needed for https://github.com/pop-os/iced/pull/149.

Not sure what is still needed for this to be merged into upstream smithay-clipboard, but that's unrelated here.